### PR TITLE
feat: adds method for overriding home-manager configuration

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,6 +7,7 @@
         "source=jmgilman-dev-container-ext,target=/home/vscode/.vscode-server/extensions,type=volume",
         "source=jmgilman-dev-container-extin,target=/home/vscode/.vscode-server-insiders/extensions,type=volume"
     ],
+    "postStartCommand": "cd /workspaces/dev-container && nix develop -c /bin/bash -c \"echo 'Pre-loading complete!'\"",
     "remoteUser": "vscode",
     "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - master
     paths:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN sed -i 's/%sudo.*ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers && \
 
 # Copy configs
 USER ${USER}
-RUN mkdir -p /home/${USER}/.config/devcontainer
+RUN mkdir -p /home/${USER}/.config/devcontainer/extra && touch /home/${USER}/.config/devcontainer/extra/.flakekeep
 COPY --chown=${USER}:${USER} config/flake.nix /home/${USER}/.config/devcontainer/flake.nix
 COPY --chown=${USER}:${USER} config/flake.lock /home/${USER}/.config/devcontainer/flake.lock
 COPY --chown=${USER}:${USER} config/config.nix /home/${USER}/.config/devcontainer/config.nix

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN sed -i 's/%sudo.*ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers && \
 
 # Copy configs
 USER ${USER}
-RUN mkdir -p /home/${USER}/.config/devcontainer/extra && touch /home/${USER}/.config/devcontainer/extra/.flakekeep
+RUN mkdir -p /home/${USER}/.config/devcontainer/extra
 COPY --chown=${USER}:${USER} config/flake.nix /home/${USER}/.config/devcontainer/flake.nix
 COPY --chown=${USER}:${USER} config/flake.lock /home/${USER}/.config/devcontainer/flake.lock
 COPY --chown=${USER}:${USER} config/config.nix /home/${USER}/.config/devcontainer/config.nix

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG NIX_INSTALLER=https://nixos.org/nix/install
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install deps required by Nix installer
-RUN apt update && apt upgrade -y && apt install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     sudo \
@@ -60,7 +60,7 @@ ENV NIX_CONF_DIR /etc
 ENV DIRENV_CONFIG /etc
 
 ## Install vscode deps
-RUN apt update && apt upgrade -y && apt install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     gnupg \
@@ -68,18 +68,17 @@ RUN apt update && apt upgrade -y && apt install -y \
     sudo
 
 # Create user
-RUN apt update && apt upgrade -y && apt install -y sudo ca-certificates && \
-    groupadd -g ${GID} ${USER} && \
+RUN groupadd -g ${GID} ${USER} && \
     useradd -u ${UID} -g ${GID} -G sudo -m ${USER} -s /bin/bash
 COPY --from=base --chown=${USER}:${USER} /home/${USER} /home/${USER}
 
 # Configure en_US.UTF-8 locale
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends locales && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen
 
 # Configure sudo
-RUN apt install -y sudo && \
+RUN apt-get install -y --no-install-recommends sudo && \
     sed -i 's/%sudo.*ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
 # Setup Nix environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG UID
 ARG GID
 ARG NIX_INSTALLER=https://nixos.org/nix/install
 
+# Set shell and check for pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install deps required by Nix installer
 RUN apt update && apt upgrade -y && apt install -y \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,17 +23,19 @@ RUN apt update && apt upgrade -y && apt install -y \
 RUN groupadd -g ${GID} ${USER} && \
     useradd -u ${UID} -g ${GID} -G sudo -m ${USER} -s /bin/bash
 
-# Install Nix and enable flakes
-ENV USER=${USER}
-ENV NIX_PATH=/home/${USER}/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels
-ENV NIX_CONF_DIR /etc
+# Configure sudo and Nix
 RUN sed -i 's/%sudo.*ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers && \
-    curl -L ${NIX_INSTALLER} | sudo -u ${USER} NIX_INSTALLER_NO_MODIFY_PROFILE=1 sh && \
     echo "sandbox = false" > /etc/nix.conf && \
     echo "experimental-features = nix-command flakes" >> /etc/nix.conf
 
-# Copy configs
+# Install Nix and enable flakes
 USER ${USER}
+ENV USER=${USER}
+ENV NIX_PATH=/home/${USER}/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels
+ENV NIX_CONF_DIR /etc
+RUN curl -L ${NIX_INSTALLER} | NIX_INSTALLER_NO_MODIFY_PROFILE=1 sh
+
+# Copy configs
 RUN mkdir -p /home/${USER}/.config/devcontainer/extra
 COPY --chown=${USER}:${USER} config/flake.nix /home/${USER}/.config/devcontainer/flake.nix
 COPY --chown=${USER}:${USER} config/flake.lock /home/${USER}/.config/devcontainer/flake.lock

--- a/config/config.nix
+++ b/config/config.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, machnix, ... }:
+{ config, pkgs, ... }:
 {
   # User-specific packages
   home.packages = [
@@ -21,6 +21,9 @@
     pkgs.ripgrep
     pkgs.tldr
   ];
+
+  # Enable home-manager
+  programs.home-manager.enable = true;
 
   # Enable direnv with nix support
   programs.direnv = {

--- a/config/flake.lock
+++ b/config/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1652452047,
+        "narHash": "sha256-O6DI0dMH/5rNM+z9CQ/nqRMNBpNsU7TtLSsafKLZTHY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "32a7da69dc53c9eb5ad0675eb7fdc58f7fe35272",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1652572281,
+        "narHash": "sha256-UEsrB5XBOj0blVe2ldc0lHvlhLYZJDHroELMHlg7XxA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "43ff6cb1c027d13dc938b88eb099462210fea52f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/config/flake.nix
+++ b/config/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Configuration of vscode";
+
+  inputs = {
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { home-manager, ... }:
+    let
+      system = "ARCH";
+      username = "USER";
+    in {
+      homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
+        # Specify the path to your home configuration here
+        configuration = import ./config.nix;
+
+        inherit system username;
+        homeDirectory = "/home/${username}";
+      };
+    };
+}

--- a/config/flake.nix
+++ b/config/flake.nix
@@ -15,6 +15,7 @@
       homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
         # Specify the path to your home configuration here
         configuration = import ./config.nix;
+        extraModules = map (n: "${./extra}/${n}") (builtins.attrNames (builtins.readDir ./extra));
 
         inherit system username;
         homeDirectory = "/home/${username}";

--- a/flake.nix
+++ b/flake.nix
@@ -8,14 +8,30 @@
   outputs = { self, nixpkgs, flake-utils, pre-commit-hooks }:
     flake-utils.lib.eachDefaultSystem (system:
       let
+        # Inherit system packages
         pkgs = import nixpkgs {
           inherit system;
         };
+
+        # Configure home-manager overrides
+        hm = pkgs.lib.generators.toPretty {} {
+          programs.zsh = {
+            envExtra = ''
+              # Custom functions
+              cc() {
+                cog commit $@ && git commit --amend --no-edit
+              }
+            '';
+          };
+        };
+
+        # Create a wrapper for enforcing conventional commit messages
         checkCommit = pkgs.writeShellScriptBin "checkCommit" ''
           cog verify "$(cat $1)"
         '';
       in
       {
+        # Add custom pre-commit checks
         checks = {
           pre-commit-check = pre-commit-hooks.lib.${system}.run {
             src = ./.;
@@ -31,12 +47,28 @@
             };
           };
         };
+
+        # Configure development environment
         devShell = pkgs.mkShell {
-          inherit (self.checks.${system}.pre-commit-check) shellHook;
+          inherit (self.checks.${system}.pre-commit-check);
+          shellHook = ''
+            ${self.checks.${system}.pre-commit-check.shellHook}
+            # Push local home-manager config to filesystem
+            cat <<EOT > /tmp/local.nix
+            { config, pkgs, ... }:
+              ${hm}
+            EOT
+
+            # If something has changed, replace the config and call switch
+            if ! cmp --silent -- /tmp/local.nix ~/.config/devcontainer/extra/local.nix; then
+              cp /tmp/local.nix ~/.config/devcontainer/extra/local.nix
+              home-manager switch --flake ~/.config/devcontainer#vscode
+            fi
+          '';
           packages = [
             checkCommit
-            pkgs.hadolint
             pkgs.cocogitto
+            pkgs.hadolint
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           shellHook = ''
             ${self.checks.${system}.pre-commit-check.shellHook}
             # Push local home-manager config to filesystem
-            cat <<EOT > /tmp/local.nix
+            cat << 'EOT' > /tmp/local.nix
             { config, pkgs, ... }:
               ${hm}
             EOT


### PR DESCRIPTION
This PR attempts to address #1 by moving to a flake-based configuration. The idea is to support loading modules from a hardcoded directory where end-users can write configs.